### PR TITLE
re-increase timeout to 10 minutes for mongo conn

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func init() {
 }
 
 func mongoConnection(url string) *mgo.Session {
-	s, err := mgo.DialWithTimeout(url, 1*time.Minute)
+	s, err := mgo.DialWithTimeout(url, 10*time.Minute)
 	if err != nil {
 		log.Fatal("err connecting to mongo instance: ", err)
 	}


### PR DESCRIPTION
Not sure why we sometimes take a long time to connect
but reverting to prior behavior

see this commit for where the regression was introduced:
https://github.com/Clever/mongo-to-s3/commit/93be945aa610fe44e6cfef2f791345ec379b5318