### PR TITLE
Prepare mongo-to-s3 for use in workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # mongo-to-s3
-Exports whitelisted `mongo` fields to an `s3` bucket, kicking off an `s3-to-redshift` job at the end of the run.
+Exports whitelisted `mongo` fields to an `s3` bucket.
  
 ## Usage:
 ```
   -config string
         String corresponding to an env var config
-  -collections string
-        Comma-separated strings corresponding to the mongo collections you wish to pull from. Empty or not set pulls all collections included in the conf file. (default: "")
+  -collection string
+        The mongo collection you wish to pull from (required)
   -database string
         Database url if using existing instance (required)
   -bucket string
@@ -24,7 +24,8 @@ Exports whitelisted `mongo` fields to an `s3` bucket, kicking off an `s3-to-reds
   - pulls the whitelisted fields from mongo
   - flattens objects into dot-separated fields
   - streams to gzipped, timestamped JSON files on s3
-5. kicks off an [s3-to-redshift](https://github.com/Clever/s3-to-redshift) job to process this data
+5. prints the payload to be used in a [s3-to-redshift](https://github.com/Clever/s3-to-redshift) job to process this data
+  - the job is kickstarted automatically by a workflow
 
 Right now, `mongo-to-s3` will attempt export all fields/tables in the `X_config.yml` whitelist which it's called with.
 
@@ -80,4 +81,4 @@ It should be easy to add more, however.
 
 5) You may want to think about issues if some data arrives sooner than other data to the data warehouse. For instance, suppose item A is only "active" if an item B exists in the database and points to A. If you've synched over A significantly before B, it may appear that A is 'inactive' until B is synched over. In reality, A has always been 'active'.
 
-6) While you pass *collections* to run on as parameters to `mongo-to-s3`, this worker will post jobs to `s3-to-redshft` with the *destination table* names as parameters.
+6) While you pass *collections* to run on as parameters to `mongo-to-s3`, the eventual `s3-to-redshft` job will post with the *destination table* names as parameters.

--- a/main_test.go
+++ b/main_test.go
@@ -10,35 +10,30 @@ import (
 )
 
 func TestTableRetrieval(t *testing.T) {
-	gearmanAdminURL = "" // Hacky way to avoid posting a job
-
 	table1 := config.Table{Destination: "schools_dest", Source: "schools_source"}
 	table2 := config.Table{Destination: "teachers_dest", Source: "teachers_source"}
 	table3 := config.Table{Destination: "students_dest", Source: "students_source"}
-	testConfig1 := config.Config{"schools": table1, "teachers": table2, "students": table3}
+	testConfig := config.Config{"schools": table1, "teachers": table2, "students": table3}
 
-	// Test regular select source tables, in order specified
-	tables, err := getTablesFromConf("students_source,schools_source", testConfig1)
+	// Test regular select source table
+	table, err := getTableFromConf("students_source", testConfig)
 	assert.NoError(t, err)
-	assert.Equal(t, len(tables), 2)
-	assert.Equal(t, tables[0].Destination, "students_dest")
-	assert.Equal(t, tables[1].Destination, "schools_dest")
+	assert.Equal(t, table.Destination, "students_dest")
 
-	// Return error if none match
-	tables, err = getTablesFromConf("foo", testConfig1)
+	// Return error if no match
+	table, err = getTableFromConf("foo", testConfig)
 	assert.Error(t, err)
 
-	// Get all tables if none specified
-	testConfig2 := config.Config{"America": config.Table{Destination: "Hawaii"}}
-	tables, err = getTablesFromConf("", testConfig2)
-	assert.NoError(t, err)
-	assert.Equal(t, len(tables), 1)
-	assert.Equal(t, tables[0].Destination, "Hawaii")
+	// Return error if trying to get multiple collections
+	table, err = getTableFromConf("students_source,schools_source", testConfig)
+	assert.Error(t, err)
+
+	// Return error if no collection specified
+	table, err = getTableFromConf("", testConfig)
+	assert.Error(t, err)
 }
 
 func TestCreateManifest(t *testing.T) {
-	gearmanAdminURL = "" // Hacky way to avoid posting a job
-
 	reader, err := createManifest("bucket", []string{"foo", "bar"})
 	assert.NoError(t, err)
 	expectedManifest := &Manifest{


### PR DESCRIPTION
**JIRA:**
https://clever.atlassian.net/browse/IP-2009

**Overview:**
Makes it so that mongo-to-s3 requires and accepts only one collection. This makes it so that we can print the payload for use in a mongo-to-redshift workflow that would trigger a s3-to-redshift job after completion of mongo-to-s3

**Testing:**
`make test`

**Roll Out:**

- [ ] Updated config file path and collections in cron-admin jobs (as needed)
