### PR TITLE
Put s3 data into subfolders.

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,7 +123,11 @@ func formatFilename(timestamp, collectionName, fileIndex, extension string) stri
 		// add underscore for readability
 		fileIndex = fmt.Sprintf("_%s", fileIndex)
 	}
-	return fmt.Sprintf("mongo_%s_%s%s%s", collectionName, timestamp, fileIndex, extension)
+	t, _ := time.Parse(time.RFC3339, timestamp)
+	filePath := fmt.Sprintf("mongo/%s/_data_timestamp_year=%02d/_data_timestamp_month=%02d/_data_timestamp_day=%02d/",
+		collectionName, t.Year(), int(t.Month()), t.Day())
+	fileName := fmt.Sprintf("mongo_%s_%s%s%s", collectionName, timestamp, fileIndex, extension)
+	return fileName + filePath
 }
 
 func exportData(source optimus.Table, table config.Table, sink optimus.Sink, timestamp string) (int, error) {


### PR DESCRIPTION
Passion project Wednesday.
Our clever-analytics bucket is a terrible mess.
This puts data into descriptive subfolders for better processing, potentially included with spectrum later on.

I have a script to migrate data, but that comes after the deploy/confirmation this is working.