### PR TITLE
Did away with all this collection to source lookup nonsense

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -5,33 +5,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/Clever/mongo-to-s3/config"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestTableRetrieval(t *testing.T) {
-	table1 := config.Table{Destination: "schools_dest", Source: "schools_source"}
-	table2 := config.Table{Destination: "teachers_dest", Source: "teachers_source"}
-	table3 := config.Table{Destination: "students_dest", Source: "students_source"}
-	testConfig := config.Config{"schools": table1, "teachers": table2, "students": table3}
-
-	// Test regular select source table
-	table, err := getTableFromConf("students_source", testConfig)
-	assert.NoError(t, err)
-	assert.Equal(t, table.Destination, "students_dest")
-
-	// Return error if no match
-	table, err = getTableFromConf("foo", testConfig)
-	assert.Error(t, err)
-
-	// Return error if trying to get multiple collections
-	table, err = getTableFromConf("students_source,schools_source", testConfig)
-	assert.Error(t, err)
-
-	// Return error if no collection specified
-	table, err = getTableFromConf("", testConfig)
-	assert.Error(t, err)
-}
 
 func TestCreateManifest(t *testing.T) {
 	reader, err := createManifest("bucket", []string{"foo", "bar"})


### PR DESCRIPTION
For some reason we are using the collection as an indirect key. This is just confusing, and makes it so some jobs look similar but do different things:

<img width="661" alt="Screen Shot 2019-04-23 at 4 36 20 PM" src="https://user-images.githubusercontent.com/29740422/56622888-afedee00-65e6-11e9-9750-80682478ba5d.png">

<img width="655" alt="Screen Shot 2019-04-23 at 4 42 21 PM" src="https://user-images.githubusercontent.com/29740422/56622914-cac06280-65e6-11e9-9f75-2233bc09996e.png">

These two jobs look similar, but the first one actually deals with schooladmin_app_connections:

<img width="276" alt="Screen Shot 2019-04-23 at 4 43 16 PM" src="https://user-images.githubusercontent.com/29740422/56622944-f04d6c00-65e6-11e9-9670-ad396b6e9959.png">
