### PR TITLE
Updated to write to mongo_raw directory instead of mongo

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,9 +187,9 @@ func formatFilename(timestamp, collectionName, fileIndex, extension string) stri
 		fileIndex = fmt.Sprintf("_%s", fileIndex)
 	}
 	t, _ := time.Parse(time.RFC3339, timestamp)
-	filePath := fmt.Sprintf("mongo/%s/_data_timestamp_year=%02d/_data_timestamp_month=%02d/_data_timestamp_day=%02d/",
+	filePath := fmt.Sprintf("mongo_raw/%s/_data_timestamp_year=%02d/_data_timestamp_month=%02d/_data_timestamp_day=%02d/",
 		collectionName, t.Year(), int(t.Month()), t.Day())
-	fileName := fmt.Sprintf("mongo_%s_%s%s%s", collectionName, timestamp, fileIndex, extension)
+	fileName := fmt.Sprintf("mongo_raw_%s_%s%s%s", collectionName, timestamp, fileIndex, extension)
 	return filePath + fileName
 }
 


### PR DESCRIPTION
This really shouldn't be hardcoded. Instead, we should pull this value from the config meta and then pass it along to s3-to-redshift instead of having the schema for that worker in the cron job.