### PR TITLE
Fix fieldpath cannot be empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,7 +175,9 @@ func configuredOptimusTable(s *mgo.Session, table config.Table) optimus.Table {
 	if table.Meta.UseProjectionOptimization == true {
 		// Create a projection to only pull the fields we're interested in
 		for _, f := range table.Fields {
-			fields[f.Source] = 1
+			if f.Source != "" {
+				fields[f.Source] = 1
+			}
 		}
 	}
 


### PR DESCRIPTION
**JIRA:**
https://clever.atlassian.net/browse/IPOC-1555

**Overview:**
In our config files, we have _data_timestamp with no source field which leads to the mongo error (prob surfaced after the db upgrade?). They get populated from the worker so it's not necessary to add to the field projection. The issue only applied to jobs with projection_optimization: true

**Testing:**
Ran locally with schooladmin_app_connections

**Roll Out:**

- [ ] Updated config file path and collections in cron-admin jobs (as needed)
