### PR TITLE
update mgo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,6 @@ require (
 	gopkg.in/Clever/kayvee-go.v6 v6.24.0
 	gopkg.in/Clever/optimus.v3 v3.7.0
 	gopkg.in/fatih/set.v0 v0.1.0 // indirect
-	gopkg.in/mgo.v2 v2.0.0-20160316054952-b6e2fa371e64
+	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fatih/set.v0 v0.1.0 h1:aaCY9PUgkH430Tl9sN6N5FqNeEfGgmPnGlY0r9WYZAE=
 gopkg.in/fatih/set.v0 v0.1.0/go.mod h1:5eLWEndGL4zGGemXWrKuts+wTJR0y+w+auqUJZbmyBg=
-gopkg.in/mgo.v2 v2.0.0-20160316054952-b6e2fa371e64 h1:eQ6pcYk7moFajn3D5Ms1oslBuUcWOniZUVDg0tGDteQ=
-gopkg.in/mgo.v2 v2.0.0-20160316054952-b6e2fa371e64/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
+gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 h1:VpOs+IwYnYBaFnrNAeB8UUWtL3vEUnzSCL1nVjPhqrw=
+gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
**JIRA:**
https://clever.atlassian.net/browse/DEIP-506

**Overview:**
Trying to move mongo-to-s3 to pods and we need to switch to private link. Update mgo driver in the hopes that it solves the sporadic failures

https://clever.atlassian.net/browse/INFRANG-4258

**Testing:**
Ran locally on `{"current":{"bucket":"clever-analytics-dev","collection":"schooladmin_app_connections","config":"app_sis","numfiles": "32"}}`

**Roll Out:**
Will monitor mongo-to-redshift jobs


- [ ] Updated config file path and collections in cron-admin jobs (as needed)
