### PR TITLE
use default primary read

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func mongoConnection(url string) *mgo.Session {
 		log.ErrorD("mongo-dial-error", logger.M{"error": err.Error()})
 		os.Exit(1)
 	}
-	s.SetMode(mgo.Monotonic, true)
+	s.SetMode(mgo.Primary, true)
 	return s
 }
 


### PR DESCRIPTION
Mongo to redshift job is failing all the time again and not sure why. This was the other option that worked when I tried it before so maybe it'll work better. Originally I went with monotonic out of the options because it seemed more robust. Not sure why anything changed to make it not work though (and it's not really worth investigating if this works since we're going to move off of it eventually anyway).

Jobs are passing now as is (students job passed 6 of last 7, student_app_connections 7/7)
