### PR TITLE
update to go1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/go/src/github.com/Clever/mongo-to-s3
     docker:
-    - image: cimg/go:1.16
+    - image: cimg/go:1.21
     - image: circleci/mongo:3.2.20-jessie-ram
     environment:
       GOPRIVATE: github.com/Clever/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm-slim
 RUN apt-get -y update && \
     apt-get install -y ca-certificates
 COPY bin/mongo-to-s3 /usr/bin/mongo-to-s3

--- a/go.mod
+++ b/go.mod
@@ -1,39 +1,59 @@
 module github.com/Clever/mongo-to-s3
 
-go 1.16
+go 1.21
 
 require (
 	github.com/Clever/analytics-latency-config-service v0.2.1
 	github.com/Clever/analytics-util v1.2.1
 	github.com/Clever/discovery-go v1.4.1-0.20160421203403-12684ef3012b
 	github.com/Clever/pathio v3.1.2-0.20160428201732-0e1d760e1bb1+incompatible
+	github.com/aws/aws-sdk-go v1.29.15
+	github.com/pquerna/ffjson v0.0.0-20180717144149-af8b230fcd20
+	github.com/stretchr/testify v1.6.1
+	gopkg.in/Clever/kayvee-go.v6 v6.24.0
+	gopkg.in/Clever/optimus.v3 v3.7.0
+	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
+	gopkg.in/yaml.v2 v2.3.0
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200817114649-df4adffc9d8c // indirect
-	github.com/aws/aws-sdk-go v1.29.15
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b // indirect
 	github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c // indirect
 	github.com/facebookgo/errgroup v0.0.0-20160209021148-779c8d7ef069 // indirect
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 // indirect
+	github.com/go-openapi/analysis v0.19.10 // indirect
+	github.com/go-openapi/errors v0.19.7 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.4 // indirect
+	github.com/go-openapi/loads v0.19.5 // indirect
 	github.com/go-openapi/runtime v0.19.22 // indirect
 	github.com/go-openapi/spec v0.19.9 // indirect
+	github.com/go-openapi/strfmt v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.9 // indirect
 	github.com/go-openapi/validate v0.19.11 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/google/go-cmp v0.5.4 // indirect
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pquerna/ffjson v0.0.0-20180717144149-af8b230fcd20
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
-	github.com/stretchr/testify v1.6.1
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.1.1-0.20190414155507-6c00ba4a5316 // indirect
 	go.mongodb.org/mongo-driver v1.4.1 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/Clever/kayvee-go.v3 v3.0.0 // indirect
-	gopkg.in/Clever/kayvee-go.v6 v6.24.0
-	gopkg.in/Clever/optimus.v3 v3.7.0
 	gopkg.in/fatih/set.v0 v0.1.0 // indirect
-	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -275,7 +275,6 @@ golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -297,7 +296,6 @@ golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/Clever/kayvee-go.v3 v3.0.0 h1:2ZFxTP3fODYxOxI3UC3saYHnjz3a5AJvC0c+E3MThXs=
 gopkg.in/Clever/kayvee-go.v3 v3.0.0/go.mod h1:GMeldd8wc48O1PB0R2Hhz4TDDg+akUngDmm0H3rGm2c=

--- a/golang.mk
+++ b/golang.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 1.0.1
+GOLANG_MK_VERSION := 1.2.1
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
@@ -47,6 +47,8 @@ golang-ensure-curl-installed:
 # Golint is a tool for linting Golang code for common errors.
 # We pin its version because an update could add a new lint check which would make
 # previously passing tests start failing without changing our code.
+# this package is deprecated and frozen
+# Infra recomendation is to eventaully move to https://github.com/golangci/golangci-lint so don't fail on linting error for now
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
 	go install -mod=readonly golang.org/x/lint/golint@738671d3881b9731cc63024d5d88cf28db875626
@@ -74,14 +76,6 @@ endef
 # golang-lint-deps-strict requires the golint tool for golang linting.
 golang-lint-deps-strict: $(GOLINT) $(FGT)
 
-# golang-lint-strict calls golint on all golang files in the pkg and fails if any lint
-# errors are found.
-# arg1: pkg path
-define golang-lint-strict
-@echo "LINTING $(1)..."
-@PKG_PATH=$$(go list -f '{{.Dir}}' $(1)); find $${PKG_PATH}/*.go -type f | grep -v gen_ | xargs $(FGT) $(GOLINT)
-endef
-
 # golang-test-deps is here for consistency
 golang-test-deps:
 
@@ -100,6 +94,21 @@ golang-test-strict-deps:
 define golang-test-strict
 @echo "TESTING $(1)..."
 @go test -v -race $(1)
+endef
+
+# golang-test-strict-cover-deps is here for consistency
+golang-test-strict-cover-deps:
+
+# golang-test-strict-cover uses the Go toolchain to run all tests in the pkg with the race and cover flag.
+# appends coverage results to coverage.txt
+# arg1: pkg path
+define golang-test-strict-cover
+@echo "TESTING $(1)..."
+@go test -v -race -cover -coverprofile=profile.tmp -covermode=atomic $(1)
+@if [ -f profile.tmp ]; then \
+  cat profile.tmp | tail -n +2 >> coverage.txt; \
+  rm profile.tmp; \
+fi;
 endef
 
 # golang-vet-deps is here for consistency
@@ -132,16 +141,29 @@ golang-test-all-strict-deps: golang-fmt-deps golang-lint-deps-strict golang-test
 # arg1: pkg path
 define golang-test-all-strict
 $(call golang-fmt,$(1))
-$(call golang-lint-strict,$(1))
+$(call golang-lint,$(1))
 $(call golang-vet,$(1))
 $(call golang-test-strict,$(1))
+endef
+
+# golang-test-all-strict-cover-deps: installs all dependencies needed for different test cases.
+golang-test-all-strict-cover-deps: golang-fmt-deps golang-lint-deps-strict golang-test-strict-cover-deps golang-vet-deps
+
+# golang-test-all-strict-cover calls fmt, lint, vet and test on the specified pkg with strict and cover
+# requirements that no errors are thrown while linting.
+# arg1: pkg path
+define golang-test-all-strict-cover
+$(call golang-fmt,$(1))
+$(call golang-lint,$(1))
+$(call golang-vet,$(1))
+$(call golang-test-strict-cover,$(1))
 endef
 
 # golang-build: builds a golang binary. ensures CGO build is done during CI. This is needed to make a binary that works with a Docker alpine image.
 # arg1: pkg path
 # arg2: executable name
 define golang-build
-@echo "BUILDING..."
+@echo "BUILDING $(2)..."
 @if [ -z "$$CI" ]; then \
 	go build -o bin/$(2) $(1); \
 else \
@@ -149,6 +171,10 @@ else \
 	CGO_ENABLED=0 go build -installsuffix cgo -o bin/$(2) $(1); \
 fi;
 endef
+
+# golang-setup-coverage: set up the coverage file
+golang-setup-coverage:
+	@echo "mode: atomic" > coverage.txt
 
 # golang-update-makefile downloads latest version of golang.mk
 golang-update-makefile:

--- a/main.go
+++ b/main.go
@@ -270,10 +270,11 @@ type Manifest struct {
 // createManifest creates a manifest file given the list of files to include into the file
 // it returns a reader for convenience
 // looks something like:
-//  { "entries": [
-//    {"url": "s3://clever-analytics/mongo_students_1_2016-01-27T21:00:00Z.json.gz", "mandatory": true},
-//    {"url": "s3://clever-analytics/mongo_students_2_2016-01-27T21:00:00Z.json.gz", "mandatory": true}
-//  ] }
+//
+//	{ "entries": [
+//	  {"url": "s3://clever-analytics/mongo_students_1_2016-01-27T21:00:00Z.json.gz", "mandatory": true},
+//	  {"url": "s3://clever-analytics/mongo_students_2_2016-01-27T21:00:00Z.json.gz", "mandatory": true}
+//	] }
 func createManifest(bucket string, dataFilenames []string) (io.Reader, error) {
 	var entryArray EntryArray
 	for _, fn := range dataFilenames {

--- a/sfncli.mk
+++ b/sfncli.mk
@@ -1,10 +1,13 @@
 # This is the default sfncli Makefile.
 # Please do not alter this file directly.
-SFNCLI_MK_VERSION := 0.1.1
+SFNCLI_MK_VERSION := 0.1.2
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 SFNCLI_INSTALLED := $(shell [[ -e "bin/sfncli" ]] && bin/sfncli --version)
-SFNCLI_LATEST = $(shell curl -s https://api.github.com/repos/Clever/sfncli/releases/latest | grep tag_name | cut -d\" -f4)
+# AUTH_HEADER is used to help avoid github ratelimiting
+AUTH_HEADER = $(shell [[ ! -z "${GITHUB_API_TOKEN}" ]] && echo "Authorization: token $(GITHUB_API_TOKEN)")
+SFNCLI_LATEST = $(shell \
+	curl -f -s https://api.github.com/repos/Clever/sfncli/releases | jq -r 'map(select(.prerelease)) | .[0].tag_name')
 
 .PHONY: bin/sfncli sfncli-update-makefile ensure-sfncli-version-set ensure-curl-installed
 
@@ -21,14 +24,21 @@ bin/sfncli: ensure-sfncli-version-set ensure-curl-installed
 	@mkdir -p bin
 	$(eval SFNCLI_VERSION := $(if $(filter latest,$(SFNCLI_VERSION)),$(SFNCLI_LATEST),$(SFNCLI_VERSION)))
 	@echo "Checking for sfncli updates..."
+	@# AUTH_HEADER not added to curl command below because it doesn't play well with redirects
 	@if [[ "$(SFNCLI_VERSION)" == "$(SFNCLI_INSTALLED)" ]]; then \
-		echo "Using latest sfncli version $(SFNCLI_VERSION)"; \
+		{ [[ -z "$(SFNCLI_INSTALLED)" ]] && \
+			{ echo "❌  Error: Failed to download sfncli.  Try setting GITHUB_API_TOKEN"; exit 1; } || \
+			{ echo "Using latest sfncli version $(SFNCLI_VERSION)"; } \
+		} \
 	else \
 		echo "Updating sfncli..."; \
 		curl --retry 5 --fail --max-time 30 -o bin/sfncli -sL https://github.com/Clever/sfncli/releases/download/$(SFNCLI_VERSION)/sfncli-$(SFNCLI_VERSION)-$(SYSTEM)-amd64 && \
 		chmod +x bin/sfncli && \
-		echo "Successfully updated sfncli to $(SFNCLI_LATEST)" || \
-		{ echo "Failed to update sfncli"; exit 1; } \
+		echo "Successfully updated sfncli to $(SFNCLI_VERSION)" || \
+		{ [[ -z "$(SFNCLI_INSTALLED)" ]] && \
+			{ echo "❌  Error: Failed to update sfncli"; exit 1; } || \
+			{ echo "⚠️  Warning: Failed to update sfncli using pre-existing version"; } \
+		} \
 	;fi
 
 sfncli-update-makefile: ensure-curl-installed


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/INFRANG-5737

**Overview:**
This is a combination of the go 1.21 upgrade, + sfncli and docker changes needed to avoid the glibc issue. This had to be rebased on master to avoid go.mod changes being overwritten and downgrading imports accidentally. 

We are asking the teams to review **AND TEST**  these PRs in clever-dev as they have greater context on what those tests should look like. 

NOTE: Since our local/ci testing do not use the same docker images as production all testing should be done by actually deploying this modified version. 

If there are any problems and you need help feel free to reach out via slack in #go121-update 

When you are finished testing please edit this PR description to add testing notes so that it passes SOC2 validation and check it off in the [spreadsheet](https://docs.google.com/spreadsheets/d/1F2nCsxteStDIxJ0sugP5ihjVFsJrjbKTV75x25gYOPo/edit?usp=sharing).

**Testing:**


**Roll Out:**
Once this is merged and all other workers are merged I will be able to update sfncli master, and then go back and change the sfncli.mk code to grab "latest" again instead of the "pre-release". 
